### PR TITLE
Prevent passphrase dialog from showing multiple times

### DIFF
--- a/src/modals/PassphraseModal.ts
+++ b/src/modals/PassphraseModal.ts
@@ -13,6 +13,7 @@ export default class PassphraseModal extends Modal {
     
 	openAndAwait(additionalDescription?: string){
 		this.additionalDescription = additionalDescription;
+		this.containerEl.style.zIndex = "10001";
 
 		return new Promise<string>((resolve, reject) => {
 			this.resolve = resolve;


### PR DESCRIPTION
Hi, here is my PR as promised. Works for me right now, but not tested/used for longer time.

Some caveats.

For some reason I couldn't replicate one of my original annoyances today. Maybe some changes in Obsidian APIs or my setup, but it is very simple vault... Anyway, initially when debugging I got very annoying situation where on vault opening initial passphrase dialog was below "Loading..." and thus unvisible.

My initial assumption was that `while (true) ...` loop in `decrypt()` method was to overcome this by spawning additional dialogs. Now I'm not so sure as problem disappeared by itself. My solution was to change dialog `z-index` value to be higher than loading modal's value. Kept this change in PR just in case, should not break anything.

Next was to remove `while (true) ...` loop as I can't see any (other) reason for it and it was responsible for infinite dialog popups (some time ago, could not replicate today). This still leaves 2-3 popups, as you originally mentioned as a result of Obsidian's async calls to read file contents. This is solved by creating and storing new promises to be resolved or rejected later, when we get reply from original passphrase dialog.

Feel free to change variable or type names as needed, I'm not very good at naming these.

Best regards and thank you for this great plugin!! 