### PR TITLE
Add encrypt/decrypt hotkeys + minor type fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "obsidian-gpgCrypt",
-	"version": "0.3.0",
+	"version": "0.5.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "obsidian-gpgCrypt",
-			"version": "0.3.0",
+			"version": "0.5.0",
 			"license": "MIT",
 			"devDependencies": {
 				"@openpgp/web-stream-tools": "^0.1.3",

--- a/src/main.ts
+++ b/src/main.ts
@@ -210,6 +210,60 @@ export default class GpgPlugin extends Plugin {
 				} 
 			})
 		);
+
+		this.addCommand({
+			id: 'gpg-encrypt-permanently',
+			name: 'GPG-Crypt: Encrypt file permanently',
+			checkCallback: (checking: boolean) => {
+				const activeFile = this.app.workspace.getActiveFile();
+				if (!activeFile) {
+					return false;
+				}
+
+				if (activeFile.extension !== "md" && activeFile.extension !== "gpg") {
+					return false;
+				}
+
+				const isEncrypted = this.encryptedFileStatus.get(activeFile.path);
+
+				if (isEncrypted === true) {
+					return false;
+				}
+
+				if (!checking) {
+					this.persistentFileEncrypt(activeFile);
+				}
+
+				return true;
+			},
+		});
+
+		this.addCommand({
+			id: 'gpg-decrypt-permanently',
+			name: 'GPG-Crypt: Decrypt file permanently',
+			checkCallback: (checking: boolean) => {
+				const activeFile = this.app.workspace.getActiveFile();
+				if (!activeFile) {
+					return false;
+				}
+
+				if (activeFile.extension !== "md" && activeFile.extension !== "gpg") {
+					return false;
+				}
+
+				const isEncrypted = this.encryptedFileStatus.get(activeFile.path);
+				
+				if (isEncrypted === false) {
+					return false;
+				}
+
+				if (!checking) {
+					this.persistentFileDecrypt(activeFile);
+				}
+
+				return true;
+			},
+		});
 	}
 
 	override async onunload(): Promise<void> {

--- a/src/settings/SettingsTab.ts
+++ b/src/settings/SettingsTab.ts
@@ -8,6 +8,11 @@ import GpgPlugin from "src/main";
 import DialogModal from "src/modals/DialogModal";
 import WelcomeModal from "src/modals/WelcomeModal";
 
+interface GpgKeyInfo {
+  keyID: string;
+  userID: string;
+}
+
 export class SettingsTab extends PluginSettingTab {
 	app: App;
 	plugin: GpgPlugin;
@@ -402,7 +407,7 @@ export class SettingsTab extends PluginSettingTab {
 
 	private async refreshRecipientSetting() {
 		// Fetching public keys and updating the dropdown
-		const keys = await this.plugin.gpgWrapper.getPublicKeys();
+		const keys: GpgKeyInfo[] = await this.plugin.gpgWrapper.getPublicKeys();
 
 		// Clear recipient field
 		this.recipientSetting.clear();


### PR DESCRIPTION
 I add any change just to have hotkey for your plugin on Obsidian. If you wish, you can add this on the original plugin.
 The reason it the same of my description on branch:
 "Now you can set custom hotkeys for encryption and decryption. This makes it possible to decrypt a note in-place and jump between its header links, instead of manually opening the note and choosing _Decrypt permanently_ which re-encrypts it as soon as you make one change"
 Have fun
 
 u r my f1rst f0rk <3