### PR TITLE
ValidateFolderIsInSettings shall not perform validation, when encryptAll is turned on.

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -473,9 +473,7 @@ export default class GpgPlugin extends Plugin {
 
 			const isEncrypted = await this.gpgNative.isEncrypted(content);
 
-
-			if (!this.settings.encryptAll)
-				new FolderInSettingValidator(this.settings).validate(normalizedPath);
+			new FolderInSettingValidator(this.settings).validate(normalizedPath);
 
 			try {
 				if (content != null && isEncrypted) {

--- a/src/settings/validators/ValidateFolderIsInSettings.ts
+++ b/src/settings/validators/ValidateFolderIsInSettings.ts
@@ -6,9 +6,12 @@ export class FolderInSettingValidator implements IValidator<string> {
 
 	constructor(private readonly settings: Settings) { }
 
-
 	validate(filePath: string) {
 		const normalizedFilePath = path.resolve(filePath);
+
+		if (this.settings.encryptAll) {
+			return this;
+		}
 
 		//if the paths are just equal
 		if (this.settings.foldersToEncrypt?.some(folder => folder === filePath)) {
@@ -26,6 +29,5 @@ export class FolderInSettingValidator implements IValidator<string> {
 
 		return this;
 	}
-
 
 } 


### PR DESCRIPTION
Most probably, this is not the cause of #43 , but I think it is worth to fix it anyways.