### PR TITLE
Replace usage of path by normalizePath

### DIFF
--- a/src/settings/validators/ValidateFolderIsInSettings.ts
+++ b/src/settings/validators/ValidateFolderIsInSettings.ts
@@ -1,31 +1,37 @@
 import { IValidator, ValidationError } from "./IValidator";
 import { Settings } from "../Settings";
-import * as path from "path";
+import { normalizePath } from "obsidian";
 
 export class FolderInSettingValidator implements IValidator<string> {
-
-	constructor(private readonly settings: Settings) { }
-
+	constructor(private readonly settings: Settings) {}
 
 	validate(filePath: string) {
-		const normalizedFilePath = path.resolve(filePath);
+		const normalizedFilePath = normalizePath(filePath);
 
 		//if the paths are just equal
-		if (this.settings.foldersToEncrypt?.some(folder => folder === filePath)) {
+		if (
+			this.settings.foldersToEncrypt?.some(
+				(folder) => folder === filePath
+			)
+		) {
 			return this;
 		}
 
-		const isInAllowedFolder = this.settings.foldersToEncrypt?.some(folder => {
-			const normalizedFolder = path.resolve(folder);
-			return normalizedFilePath.startsWith(normalizedFolder + path.sep);
-		});
+		const isInAllowedFolder = this.settings.foldersToEncrypt?.some(
+			(folder) => {
+				const normalizedFolder = normalizePath(folder);
+				return normalizedFilePath.startsWith(normalizedFolder + "/");
+			}
+		);
 
 		if (!isInAllowedFolder) {
-			throw new ValidationError("FolderInSettingValidator", "This folder isn't in your path.", filePath + " folder not in path, ignoring.");
+			throw new ValidationError(
+				"FolderInSettingValidator",
+				"This folder isn't in your path.",
+				filePath + " folder not in path, ignoring."
+			);
 		}
 
 		return this;
 	}
-
-
-} 
+}


### PR DESCRIPTION
This PR fixes #50, by using `normalizePath` from `obsidian` instead of importing NodeJS `path` on mobile.

Tested by emulating mobile via developper tools.