### PR TITLE
Fix. Showing headers for encrypted files

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -412,8 +412,10 @@ export default class GpgPlugin extends Plugin {
 		if (!this.encryptedFileStatus.has(normalizedPath) || this.encryptedFileStatus.get(normalizedPath) !== true) {
 			this.encryptedFileStatus.set(normalizedPath, isEncrypted);
 		}
-
-		if (!isEncrypted || !this.settings.compatibilityMode) {
+		
+		// Worker Obsidian uses readBinary to parse metadata 
+		// which is necessary for showing headers and so on.
+		if (!isEncrypted || !this.settings.showOutlineHeadings) {
 			return contentArray;
 		}
 
@@ -551,6 +553,38 @@ export default class GpgPlugin extends Plugin {
 			if (await this.gpgNative.isEncrypted(content) === false) {
 				return await this.encrypt(content);
 			}
+
+			return content;
+		}
+
+		// vault.cachedRead maintains its own internal content cache that is
+		// populated at vault startup — BEFORE the plugin (and its adapter.read hook)
+		// is loaded. As a result, originalVaultCachedRead may return stale
+		// encrypted content even though adapter.read is already hooked.
+		// Consumers such as MetadataCache call cachedRead, so they would index
+		// the raw PGP ciphertext and headings would never appear in the sidebar.
+		// Fix: detect encrypted content and decrypt it here, reusing the same
+		// decryptionCache that hookedAdapterRead uses to coalesce concurrent calls.
+		if (await this.gpgNative.isEncrypted(content)) {
+			if (this.decryptionCache.has(content)) {
+				return this.decryptionCache.get(content)!;
+			}
+
+			this.decryptionCache.set(content, new Promise(async (resolve, reject) => {
+				let errorOccurred = false;
+				try {
+					resolve(await this.decrypt(file.path, content));
+				} catch (error) {
+					errorOccurred = true;
+					reject(error);
+				} finally {
+					if (errorOccurred || !this.settings.backendWrapper.cache) {
+						setTimeout(() => { _log(`Delete decryption cache (cachedRead) for ${file.path}`); this.decryptionCache.delete(content); }, 500);
+					}
+				}
+			}));
+
+			return this.decryptionCache.get(content)!;
 		}
 
 		return content;
@@ -1004,6 +1038,8 @@ export default class GpgPlugin extends Plugin {
 			askPassphraseOnStartup: false,
 			passphraseTimeout: 300,
 			resetPassphraseTimeoutOnWrite: false,
+
+			showOutlineHeadings: true,
 		}
 
 		this.settings = Object.assign({}, DEFAULT_SETTINGS, await this.loadData());

--- a/src/settings/Settings.ts
+++ b/src/settings/Settings.ts
@@ -28,4 +28,6 @@ export interface Settings {
 	askPassphraseOnStartup: boolean;
 	passphraseTimeout: number;
 	resetPassphraseTimeoutOnWrite: boolean;
+
+	showOutlineHeadings: boolean;
 }

--- a/src/settings/SettingsTab.ts
+++ b/src/settings/SettingsTab.ts
@@ -156,6 +156,17 @@ export class SettingsTab extends PluginSettingTab {
 		const warningEl = compatibilityModeSetting.descEl.createSpan({ cls: 'mod-warning' });
 		warningEl.innerText = "Warning: this exposes plaintext headings and file structure on disk.";
 
+		new Setting(this.containerEl)
+			.setName("Show headings in Outline panel")
+			.setDesc("When enabled, headings from encrypted notes are indexed in Obsidian's MetadataCache after keys are loaded, making them visible in the Outline panel. Disable this if you experience indexing issues.")
+			.addToggle(toggle => {
+				toggle
+					.setValue(this.settings.showOutlineHeadings)
+					.onChange(async (value) => {
+						this.settings.showOutlineHeadings = value;
+						await this.plugin.saveSettings();
+					});
+			});
 
 		new Setting(this.containerEl)
 			.setHeading()


### PR DESCRIPTION
## Description

At the moment if the file is encrypted, obsidian does not show the headers list in the right panel. I wrote a fix code of that.

## Questions

- Didn't understand meaning of compatibility mode. It's saves the content in the cache Map which is placed in RAM, seems quite secure for me. Could you please review that place?

## Changes

- Added checkbox in settings for enabling headers. Title: "Show headings in Outline panel"
- hookedVaultCachedRead now decrypts the content before returning it back